### PR TITLE
::when should imply ::get (fixes #5)

### DIFF
--- a/jinsi/parser.py
+++ b/jinsi/parser.py
@@ -115,6 +115,8 @@ class Parser:
 
     def parse_conditional(self, obj, parent: Node) -> Node:
         node = When(parent)
+        if isinstance(obj['::when'], str):
+            obj['::when'] = {'::get': obj['::when']}
         node.when = self.parse_node(obj['::when'], node)
         node.then = self.parse_node(obj['::then'], node)
         if '::else' in obj:

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -87,6 +87,21 @@ class JinsiExamples(JinsiTestCase):
 
         self.check(expected, doc)
 
+    def test_case_when_without_get(self):
+        doc = """\
+            value:
+                ::let:
+                    x: 1
+                ::when: x == 1
+                ::then:
+                    foo: one
+                ::else:
+                    bar: two
+        """
+
+        expected = {'foo': 'one'}
+
+        self.check(expected, doc)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -94,12 +94,12 @@ class JinsiExamples(JinsiTestCase):
                     x: 1
                 ::when: x == 1
                 ::then:
-                    foo: one
+                    one
                 ::else:
-                    bar: two
+                    two
         """
 
-        expected = {'foo': 'one'}
+        expected = {'value': 'one'}
 
         self.check(expected, doc)
 


### PR DESCRIPTION
When `::when` is without `::get` , `obj['::when']` is either a constant or a string . When it is a string , it needs to be put with the `::get` key. I tried this, so whenever `::when` is used without a `::get` , the `::get` is put in automatically.